### PR TITLE
Moved Simulation:MovetypeWalking(cmd) to separate MoveTypeWalking.luau file

### DIFF
--- a/example/customclient/Characters/NicerHumanoid.lua
+++ b/example/customclient/Characters/NicerHumanoid.lua
@@ -15,10 +15,14 @@ function module:Setup(simulation)
 	simulation.constants.jumpThrustPower = 300 --If you keep holding jump, how much extra vel per second is there?  (turn this off for no variable height jumps)
 	simulation.constants.jumpThrustDecay = 0.25 --Smaller is faster
 
+	local MoveTypeWalking = require(script.Parent.utils.MoveTypeWalking)
+	MoveTypeWalking:ModifySimulation(simulation)
+
     --Example on adding a flying movement type
     local MoveTypeFlying = require(script.Parent.utils.MoveTypeFlying)
     MoveTypeFlying:ModifySimulation(simulation)
     
+	simulation:SetMoveState("Walking")
 end
 
 function module:GetCharacterModel(userId)

--- a/example/customclient/Characters/utils/MoveTypeWalking.luau
+++ b/example/customclient/Characters/utils/MoveTypeWalking.luau
@@ -1,0 +1,233 @@
+local module = {}
+local path = game.ReplicatedStorage.Shared.Chickynoid
+local MathUtils = require(path.Simulation.MathUtils)
+local Enums = require(path.Enums)
+
+function module:Setup(simulation)
+    self:ModifySimulation(simulation)
+end
+
+function module:ModifySimulation(simulation)
+    simulation:RegisterMoveState("Walking", self.ActiveThink, nil, nil, nil)
+    simulation:SetMoveState("Walking")
+
+    simulation.state.up = Vector3.yAxis
+end
+
+function module:ActiveThink(cmd)
+    --Check ground
+    local onGround = nil
+    onGround = self:DoGroundCheck(self.state.pos)
+
+    --If the player is on too steep a slope, its not ground
+	if (onGround ~= nil and onGround.normal.Y < self.constants.maxGroundSlope) then
+		
+		--See if we can move downwards?
+		if (self.state.vel.y < 0.1) then
+			local stuck = self:CheckGroundSlopes(self.state.pos)
+			
+			if (stuck == false) then
+				--we moved, that means the player is on a slope and can free fall
+				onGround = nil
+			else
+				--we didn't move, it means the ground we're on is sloped, but we can't fall any further
+				--treat it like flat ground
+				onGround.normal = Vector3.new(0,1,0)
+			end
+		else
+			onGround = nil
+		end
+	end
+	
+	 
+    --Mark if we were onground at the start of the frame
+    local startedOnGround = onGround
+	
+	--Simplify - whatever we are at the start of the frame goes.
+	self.lastGround = onGround
+	
+
+    --Did the player have a movement request?
+    local wishDir = nil
+    if cmd.x ~= 0 or cmd.z ~= 0 then
+        wishDir = Vector3.new(cmd.x, 0, cmd.z).Unit
+        self.state.pushDir = Vector2.new(cmd.x, cmd.z)
+    else
+        self.state.pushDir = Vector2.new(0, 0)
+    end
+
+    --Create flat velocity to operate our input command on
+    --In theory this should be relative to the ground plane instead...
+    local flatVel = MathUtils:FlatVec(self.state.vel)
+
+    --Does the player have an input?
+    if wishDir ~= nil then
+        if onGround then
+            --Moving along the ground under player input
+
+            flatVel = MathUtils:GroundAccelerate(
+                wishDir,
+                self.constants.maxSpeed,
+                self.constants.accel,
+                flatVel,
+                cmd.deltaTime
+            )
+
+            --Good time to trigger our walk anim
+            if self.state.pushing > 0 then
+                self.characterData:PlayAnimation(Enums.Anims.Push, Enums.AnimChannel.Channel0, false)
+            else
+                self.characterData:PlayAnimation(Enums.Anims.Walk, Enums.AnimChannel.Channel0, false)
+            end
+        else
+            --Moving through the air under player control
+            flatVel = MathUtils:Accelerate(wishDir, self.constants.airSpeed, self.constants.airAccel, flatVel, cmd.deltaTime)
+        end
+    else
+        if onGround ~= nil then
+            --Just standing around
+            flatVel = MathUtils:VelocityFriction(flatVel, self.constants.brakeFriction, cmd.deltaTime)
+
+            --Enter idle
+            self.characterData:PlayAnimation(Enums.Anims.Idle, Enums.AnimChannel.Channel0, false)
+        -- else
+            --moving through the air with no input
+        end
+    end
+
+    --Turn out flatvel back into our vel
+    self.state.vel = Vector3.new(flatVel.x, self.state.vel.y, flatVel.z)
+
+    --Do jumping?
+    if self.state.jump > 0 then
+        self.state.jump -= cmd.deltaTime
+        if self.state.jump < 0 then
+            self.state.jump = 0
+        end
+    end
+
+    if onGround ~= nil then
+        --jump!
+        if cmd.y > 0 and self.state.jump <= 0 then
+            self.state.vel = Vector3.new(self.state.vel.x, self.constants.jumpPunch, self.state.vel.z)
+            self.state.jump = 0.2 --jumping has a cooldown (think jumping up a staircase)
+            self.state.jumpThrust = self.constants.jumpThrustPower
+            self.characterData:PlayAnimation(Enums.Anims.Jump, Enums.AnimChannel.Channel0, true, 0.2)
+        end
+
+        --Check jumpPads
+        if onGround.hullRecord then
+            local instance = onGround.hullRecord.instance
+
+            if instance then
+                local vec3 = instance:GetAttribute("launch")
+                if vec3 then
+                    local dir = instance.CFrame:VectorToWorldSpace(vec3)
+                    self.state.vel = dir
+                    self.state.jump = 0.2
+                    self.characterData:PlayAnimation(Enums.Anims.Jump, Enums.AnimChannel.Channel0, true, 0.2)
+                end
+            end
+        end
+    end
+
+    --In air?
+    if onGround == nil then
+        self.state.inAir += cmd.deltaTime
+        if self.state.inAir > 10 then
+            self.state.inAir = 10 --Capped just to keep the state var reasonable
+        end
+
+        --Jump thrust
+        if cmd.y > 0 then
+            if self.state.jumpThrust > 0 then
+                self.state.vel += Vector3.new(0, self.state.jumpThrust * cmd.deltaTime, 0)
+                self.state.jumpThrust = MathUtils:Friction(
+                    self.state.jumpThrust,
+                    self.constants.jumpThrustDecay,
+                    cmd.deltaTime
+                )
+            end
+            if self.state.jumpThrust < 0.001 then
+                self.state.jumpThrust = 0
+            end
+        else
+            self.state.jumpThrust = 0
+        end
+
+        --gravity
+        self.state.vel += Vector3.new(0, self.constants.gravity * cmd.deltaTime, 0)
+
+        --Switch to falling if we've been off the ground for a bit
+        if self.state.vel.y <= 0.01 and self.state.inAir > 0.5 then
+            self.characterData:PlayAnimation(Enums.Anims.Fall, Enums.AnimChannel.Channel0, false)
+        end
+    else
+        self.state.inAir = 0
+    end
+
+    --Sweep the player through the world, once flat along the ground, and once "step up'd"
+    local stepUpResult = nil
+    local walkNewPos, walkNewVel, hitSomething = self:ProjectVelocity(self.state.pos, self.state.vel, cmd.deltaTime)
+
+    --Did we crashland
+    if onGround == nil and hitSomething == true then
+        --Land after jump
+        local groundCheck = self:DoGroundCheck(walkNewPos)
+
+        if groundCheck ~= nil then
+            --Crashland
+            walkNewVel = self:CrashLand(walkNewVel, cmd, groundCheck)
+        end
+    end
+
+    -- Do we attempt a stepup?                              (not jumping!)
+    if onGround ~= nil and hitSomething == true and self.state.jump == 0 then
+        stepUpResult = self:DoStepUp(self.state.pos, self.state.vel, cmd.deltaTime)
+    end
+
+    --Choose which one to use, either the original move or the stepup
+    if stepUpResult ~= nil then
+        self.state.stepUp += stepUpResult.stepUp
+        self.state.pos = stepUpResult.pos
+        self.state.vel = stepUpResult.vel
+    else
+        self.state.pos = walkNewPos
+        self.state.vel = walkNewVel
+    end
+
+    --Do stepDown
+    if true then
+        if startedOnGround ~= nil and self.state.jump == 0 and self.state.vel.y <= 0 then
+            local stepDownResult = self:DoStepDown(self.state.pos)
+            if stepDownResult ~= nil then
+                self.state.stepUp += stepDownResult.stepDown
+                self.state.pos = stepDownResult.pos
+            end
+        end
+    end
+
+    --Do angles
+    if (self.constants.aimlock == 1) then
+        
+        if (cmd.fa) then
+            local vec = cmd.fa - self.state.pos
+
+			self.state.targetAngle  = MathUtils:PlayerVecToAngle(vec)
+			self.state.angle = MathUtils:LerpAngle(
+				self.state.angle,
+				self.state.targetAngle,
+				self.constants.turnSpeedFrac * cmd.deltaTime
+			)
+        end
+    else    
+        if wishDir ~= nil then
+            self.state.targetAngle = MathUtils:PlayerVecToAngle(wishDir)
+            self.state.angle = MathUtils:LerpAngle(
+                self.state.angle,
+                self.state.targetAngle,
+                self.constants.turnSpeedFrac * cmd.deltaTime
+            )
+        end
+    end
+end

--- a/src/Simulation/init.lua
+++ b/src/Simulation/init.lua
@@ -37,6 +37,7 @@ function Simulation.new(userId)
     self.state.jumpThrust = 0
     self.state.pushing = 0 --External flag comes from server (ungh >_<')
     self.state.moveState = 0 --Walking!
+    
 
     self.characterData = CharacterData.new()
 
@@ -53,17 +54,15 @@ function Simulation.new(userId)
     self.constants.runFriction = 0.01 --friction applied after max speed
     self.constants.brakeFriction = 0.02 --Lower is brake harder, dont use 0
     self.constants.maxGroundSlope = 0.05 --about 89o
-    self.constants.jumpThrustPower = 0    --No variable height jumping 
+    self.constants.jumpThrustPower = 0    --No variable height jumping
     self.constants.jumpThrustDecay = 0
 	self.constants.gravity = -198
 	self.constants.crashLandBehavior = Enums.Crashland.FULL_BHOP_FORWARD
 
     self.constants.pushSpeed = 16 --set this lower than maxspeed if you want stuff to feel heavy
-	self.constants.stepSize = 2.2
+	self.constants.stepSize = 2.9
 	self.constants.gravity = -198
 
-    self:RegisterMoveState("Walking", self.MovetypeWalking, nil, nil, nil)
-    self:SetMoveState("Walking")
     return self
 end
 
@@ -155,6 +154,7 @@ function Simulation:ProcessCommand(cmd)
     --Write this to the characterData
     self.characterData:SetTargetPosition(self.state.pos)
     self.characterData:SetAngle(self.state.angle)
+
     self.characterData:SetStepUp(self.state.stepUp)
     self.characterData:SetFlatSpeed( MathUtils:FlatVec(self.state.vel).Magnitude)
 
@@ -170,7 +170,7 @@ function Simulation:SetAngle(angle, teleport)
 end
 
 function Simulation:SetPosition(position, teleport)
-    self.state.position = position
+    self.state.pos = position
     self.characterData:SetTargetPosition(self.state.pos, teleport)
 end
 
@@ -233,6 +233,7 @@ end
 --STEPUP - the magic that lets us traverse uneven world geometry
 --the idea is that you redo the player movement but "if I was x units higher in the air"
 
+-- TODO: Change to only apply our smooth rolling on non-walking movesets ("NicerHumanoid" characterMod)
 function Simulation:DoStepUp(pos, vel, deltaTime)
     local flatVel = MathUtils:FlatVec(vel)
 
@@ -246,7 +247,7 @@ function Simulation:DoStepUp(pos, vel, deltaTime)
 
     --Trace back down
     local traceDownPos = stepUpNewPos
-    local hitResult = CollisionModule:Sweep(traceDownPos, traceDownPos - stepVec)
+    local hitResult = CollisionModule:Sweep(traceDownPos, traceDownPos - Vector3.new(0, self.constants.aggressiveStep, 0))
 
     stepUpNewPos = hitResult.endPos
 
@@ -283,7 +284,6 @@ function Simulation:DoStepDown(pos)
         and hitResult.normal.Y >= self.constants.maxGroundSlope
     then
         local delta = pos.y - hitResult.endPos.y
-
         if delta > 0.001 then
             local result = {
 
@@ -480,227 +480,6 @@ function Simulation:GetStandingPart()
         return self.lastGround.hullRecord.instance
     end
     return nil
-end
-
-
---Move me to my own file!
-function Simulation:MovetypeWalking(cmd)
-
-    --Check ground
-    local onGround = nil
-    onGround = self:DoGroundCheck(self.state.pos)
-
-    --If the player is on too steep a slope, its not ground
-	if (onGround ~= nil and onGround.normal.Y < self.constants.maxGroundSlope) then
-		
-		--See if we can move downwards?
-		if (self.state.vel.y < 0.1) then
-			local stuck = self:CheckGroundSlopes(self.state.pos)
-			
-			if (stuck == false) then
-				--we moved, that means the player is on a slope and can free fall
-				onGround = nil
-			else
-				--we didn't move, it means the ground we're on is sloped, but we can't fall any further
-				--treat it like flat ground
-				onGround.normal = Vector3.new(0,1,0)
-			end
-		else
-			onGround = nil
-		end
-	end
-	
-	 
-    --Mark if we were onground at the start of the frame
-    local startedOnGround = onGround
-	
-	--Simplify - whatever we are at the start of the frame goes.
-	self.lastGround = onGround
-	
-
-    --Did the player have a movement request?
-    local wishDir = nil
-    if cmd.x ~= 0 or cmd.z ~= 0 then
-        wishDir = Vector3.new(cmd.x, 0, cmd.z).Unit
-        self.state.pushDir = Vector2.new(cmd.x, cmd.z)
-    else
-        self.state.pushDir = Vector2.new(0, 0)
-    end
-
-    --Create flat velocity to operate our input command on
-    --In theory this should be relative to the ground plane instead...
-    local flatVel = MathUtils:FlatVec(self.state.vel)
-
-    --Does the player have an input?
-    if wishDir ~= nil then
-        if onGround then
-            --Moving along the ground under player input
-
-            flatVel = MathUtils:GroundAccelerate(
-                wishDir,
-                self.constants.maxSpeed,
-                self.constants.accel,
-                flatVel,
-                cmd.deltaTime
-            )
-
-            --Good time to trigger our walk anim
-            if self.state.pushing > 0 then
-                self.characterData:PlayAnimation(Enums.Anims.Push, Enums.AnimChannel.Channel0, false)
-            else
-                self.characterData:PlayAnimation(Enums.Anims.Walk, Enums.AnimChannel.Channel0, false)
-            end
-        else
-            --Moving through the air under player control
-            flatVel = MathUtils:Accelerate(wishDir, self.constants.airSpeed, self.constants.airAccel, flatVel, cmd.deltaTime)
-        end
-    else
-        if onGround ~= nil then
-            --Just standing around
-            flatVel = MathUtils:VelocityFriction(flatVel, self.constants.brakeFriction, cmd.deltaTime)
-
-            --Enter idle
-            self.characterData:PlayAnimation(Enums.Anims.Idle, Enums.AnimChannel.Channel0, false)
-        -- else
-            --moving through the air with no input
-        end
-    end
-
-    --Turn out flatvel back into our vel
-    self.state.vel = Vector3.new(flatVel.x, self.state.vel.y, flatVel.z)
-
-    --Do jumping?
-    if self.state.jump > 0 then
-        self.state.jump -= cmd.deltaTime
-        if self.state.jump < 0 then
-            self.state.jump = 0
-        end
-    end
-
-    if onGround ~= nil then
-        --jump!
-        if cmd.y > 0 and self.state.jump <= 0 then
-            self.state.vel = Vector3.new(self.state.vel.x, self.constants.jumpPunch, self.state.vel.z)
-            self.state.jump = 0.2 --jumping has a cooldown (think jumping up a staircase)
-            self.state.jumpThrust = self.constants.jumpThrustPower
-            self.characterData:PlayAnimation(Enums.Anims.Jump, Enums.AnimChannel.Channel0, true, 0.2)
-        end
-
-        --Check jumpPads
-        if onGround.hullRecord then
-            local instance = onGround.hullRecord.instance
-
-            if instance then
-                local vec3 = instance:GetAttribute("launch")
-                if vec3 then
-                    local dir = instance.CFrame:VectorToWorldSpace(vec3)
-                    self.state.vel = dir
-                    self.state.jump = 0.2
-                    self.characterData:PlayAnimation(Enums.Anims.Jump, Enums.AnimChannel.Channel0, true, 0.2)
-                end
-            end
-        end
-    end
-
-    --In air?
-    if onGround == nil then
-        self.state.inAir += cmd.deltaTime
-        if self.state.inAir > 10 then
-            self.state.inAir = 10 --Capped just to keep the state var reasonable
-        end
-
-        --Jump thrust
-        if cmd.y > 0 then
-            if self.state.jumpThrust > 0 then
-                self.state.vel += Vector3.new(0, self.state.jumpThrust * cmd.deltaTime, 0)
-                self.state.jumpThrust = MathUtils:Friction(
-                    self.state.jumpThrust,
-                    self.constants.jumpThrustDecay,
-                    cmd.deltaTime
-                )
-            end
-            if self.state.jumpThrust < 0.001 then
-                self.state.jumpThrust = 0
-            end
-        else
-            self.state.jumpThrust = 0
-        end
-
-        --gravity
-        self.state.vel += Vector3.new(0, self.constants.gravity * cmd.deltaTime, 0)
-
-        --Switch to falling if we've been off the ground for a bit
-        if self.state.vel.y <= 0.01 and self.state.inAir > 0.5 then
-            self.characterData:PlayAnimation(Enums.Anims.Fall, Enums.AnimChannel.Channel0, false)
-        end
-    else
-        self.state.inAir = 0
-    end
-
-    --Sweep the player through the world, once flat along the ground, and once "step up'd"
-    local stepUpResult = nil
-    local walkNewPos, walkNewVel, hitSomething = self:ProjectVelocity(self.state.pos, self.state.vel, cmd.deltaTime)
-
-    --Did we crashland
-    if onGround == nil and hitSomething == true then
-        --Land after jump
-        local groundCheck = self:DoGroundCheck(walkNewPos)
-
-        if groundCheck ~= nil then
-            --Crashland
-            walkNewVel = self:CrashLand(walkNewVel, cmd, groundCheck)
-        end
-    end
-
-    -- Do we attempt a stepup?                              (not jumping!)
-    if onGround ~= nil and hitSomething == true and self.state.jump == 0 then
-        stepUpResult = self:DoStepUp(self.state.pos, self.state.vel, cmd.deltaTime)
-    end
-
-    --Choose which one to use, either the original move or the stepup
-    if stepUpResult ~= nil then
-        self.state.stepUp += stepUpResult.stepUp
-        self.state.pos = stepUpResult.pos
-        self.state.vel = stepUpResult.vel
-    else
-        self.state.pos = walkNewPos
-        self.state.vel = walkNewVel
-    end
-
-    --Do stepDown
-    if true then
-        if startedOnGround ~= nil and self.state.jump == 0 and self.state.vel.y <= 0 then
-            local stepDownResult = self:DoStepDown(self.state.pos)
-            if stepDownResult ~= nil then
-                self.state.stepUp += stepDownResult.stepDown
-                self.state.pos = stepDownResult.pos
-            end
-        end
-    end
-
-    --Do angles
-    if (self.constants.aimlock == 1) then
-        
-        if (cmd.fa) then
-            local vec = cmd.fa - self.state.pos
-
-			self.state.targetAngle  = MathUtils:PlayerVecToAngle(vec)
-			self.state.angle = MathUtils:LerpAngle(
-				self.state.angle,
-				self.state.targetAngle,
-				self.constants.turnSpeedFrac * cmd.deltaTime
-			)
-        end
-    else    
-        if wishDir ~= nil then
-            self.state.targetAngle = MathUtils:PlayerVecToAngle(wishDir)
-            self.state.angle = MathUtils:LerpAngle(
-                self.state.angle,
-                self.state.targetAngle,
-                self.constants.turnSpeedFrac * cmd.deltaTime
-            )
-        end
-    end
 end
 
 return Simulation

--- a/src/Simulation/init.lua
+++ b/src/Simulation/init.lua
@@ -60,7 +60,7 @@ function Simulation.new(userId)
 	self.constants.crashLandBehavior = Enums.Crashland.FULL_BHOP_FORWARD
 
     self.constants.pushSpeed = 16 --set this lower than maxspeed if you want stuff to feel heavy
-	self.constants.stepSize = 2.9
+	self.constants.stepSize = 2.2
 	self.constants.gravity = -198
 
     return self


### PR DESCRIPTION
There was a comment in `Simulation\init.lua` that said "Move me to my own file!" right before `Simulation:MovetypeWalking(cmd)`, so I moved it to `example\customclient\Characters\utils\MoveTypeWalking.luau` alongside `MoveTypeFlying.lua` since I had already done so for my own project. In the example, I also registered the new MoveType in `example\customclient\CharactersNicerHumanoid.lua`