### PR TITLE
Character mod hotswap

### DIFF
--- a/example/customclient/Characters/HumanoidChickynoid.lua
+++ b/example/customclient/Characters/HumanoidChickynoid.lua
@@ -3,7 +3,24 @@ local ChickynoidStyle = {}
 --Gets called on both client and server
 function ChickynoidStyle:Setup(simulation)
 
-    --Dont need to set anything, the defaults should basically be this
+    --Roblox Humanoid defaultish
+    self.constants = {}
+    self.constants.maxSpeed = 16 --Units per second
+    self.constants.airSpeed = 16 --Units per second
+    self.constants.accel = 40 --Units per second per second
+    self.constants.airAccel = 10 --Uses a different function than ground accel!
+    self.constants.jumpPunch = 60 --Raw velocity, just barely enough to climb on a 7 unit tall block
+    self.constants.turnSpeedFrac = 8 --seems about right? Very fast.
+    self.constants.runFriction = 0.01 --friction applied after max speed
+    self.constants.brakeFriction = 0.02 --Lower is brake harder, dont use 0
+    self.constants.maxGroundSlope = 0.05 --about 89o
+    self.constants.jumpThrustPower = 0    --No variable height jumping
+    self.constants.jumpThrustDecay = 0
+	self.constants.gravity = -198
+
+    self.constants.pushSpeed = 16 --set this lower than maxspeed if you want stuff to feel heavy
+	self.constants.stepSize = 2.2
+	self.constants.gravity = -198
 end
 
 return ChickynoidStyle

--- a/example/customclient/Characters/HumanoidChickynoid.lua
+++ b/example/customclient/Characters/HumanoidChickynoid.lua
@@ -23,4 +23,6 @@ function ChickynoidStyle:Setup(simulation)
 	self.constants.gravity = -198
 end
 
+
+
 return ChickynoidStyle

--- a/example/customclient/Characters/NicerHumanoid.lua
+++ b/example/customclient/Characters/NicerHumanoid.lua
@@ -4,17 +4,17 @@ local StarterPlayer = game:GetService("StarterPlayer")
 
 function module:Setup(simulation)
 	-- base speed
-	simulation.constants.maxSpeed = 16 --Units per second
-	simulation.constants.airSpeed = 16 --Units per second
+	simulation.constants.maxSpeed = 24 --Units per second
+	simulation.constants.airSpeed = 24 --Units per second
 	simulation.constants.accel = 10 --Units per second per second
 	simulation.constants.airAccel = 10 --Uses a different function than ground accel!
 	simulation.constants.jumpPunch = 35 --Raw velocity, just barely enough to climb on a 7 unit tall block
 	simulation.constants.turnSpeedFrac = 10 --seems about right? Very fast.
 	simulation.constants.runFriction = 0.01 --friction applied after max speed
-	simulation.constants.brakeFriction = 0.03 --Lower is brake harder, dont use 0
-	simulation.constants.maxGroundSlope = 0.55 --about 45o
-	simulation.constants.jumpThrustPower = 300 --If you keep holding jump, how much extra vel per second is there?  (turn this off for no variable height jumps)
-	simulation.constants.jumpThrustDecay = 0.25 --Smaller is faster
+	simulation.constants.brakeFriction = 0.1 --Lower is brake harder, dont use 0
+	simulation.constants.maxGroundSlope = 0.05 --about 89o
+	simulation.constants.jumpThrustPower = 400 --If you keep holding jump, how much extra vel per second is there?  (turn this off for no variable height jumps)
+	simulation.constants.jumpThrustDecay = 0.1 --Smaller is faster
 
 	-- setup base walking state
 	local MoveTypeWalking = require(script.Parent.utils.MoveTypeWalking)

--- a/example/customclient/Characters/NicerHumanoid.lua
+++ b/example/customclient/Characters/NicerHumanoid.lua
@@ -15,10 +15,14 @@ function module:Setup(simulation)
 	simulation.constants.jumpThrustPower = 300 --If you keep holding jump, how much extra vel per second is there?  (turn this off for no variable height jumps)
 	simulation.constants.jumpThrustDecay = 0.25 --Smaller is faster
 
+	local MoveTypeWalking = require(script.Parent.utils.MoveTypeWalking)
+	MoveTypeWalking:ModifySimulation(simulation)
+
     --Example on adding a flying movement type
     local MoveTypeFlying = require(script.Parent.utils.MoveTypeFlying)
     MoveTypeFlying:ModifySimulation(simulation)
     
+	simulation:SetMoveState("Walking")
 end
 
 function module:GetCharacterModel(userId)

--- a/example/customclient/Characters/NicerHumanoid.lua
+++ b/example/customclient/Characters/NicerHumanoid.lua
@@ -25,10 +25,10 @@ function module:GetCharacterModel(userId, source)
 	local srcModel
 	local result, err = pcall(function()
 
-		-- --Bot id?
-		-- if (string.sub(userId, 1, 1) == "-") then
-		-- 	userId = string.sub(userId, 2, string.len(userId)) --drop the -
-		-- end
+		--Bot id?
+		if (string.sub(userId, 1, 1) == "-") then
+			userId = string.sub(userId, 2, string.len(userId)) --drop the -
+		end
 
 		userId = tonumber(userId)
 

--- a/example/customclient/Characters/NicerHumanoid.lua
+++ b/example/customclient/Characters/NicerHumanoid.lua
@@ -1,8 +1,9 @@
 local module = {}
 
+local StarterPlayer = game:GetService("StarterPlayer")
 
 function module:Setup(simulation)
-    
+	-- base speed
 	simulation.constants.maxSpeed = 16 --Units per second
 	simulation.constants.airSpeed = 16 --Units per second
 	simulation.constants.accel = 10 --Units per second per second
@@ -15,21 +16,61 @@ function module:Setup(simulation)
 	simulation.constants.jumpThrustPower = 300 --If you keep holding jump, how much extra vel per second is there?  (turn this off for no variable height jumps)
 	simulation.constants.jumpThrustDecay = 0.25 --Smaller is faster
 
+	-- setup base walking state
 	local MoveTypeWalking = require(script.Parent.utils.MoveTypeWalking)
 	MoveTypeWalking:ModifySimulation(simulation)
-
-    --Example on adding a flying movement type
-    local MoveTypeFlying = require(script.Parent.utils.MoveTypeFlying)
-    MoveTypeFlying:ModifySimulation(simulation)
-    
-	simulation:SetMoveState("Walking")
 end
 
-function module:GetCharacterModel(userId)
-	--return game.ReplicatedFirst.Packages.Chickynoid.Assets.BigHeadRig
-	return nil
-end 
+function module:GetCharacterModel(userId, source)
+	local srcModel
+	local result, err = pcall(function()
+
+		-- --Bot id?
+		-- if (string.sub(userId, 1, 1) == "-") then
+		-- 	userId = string.sub(userId, 2, string.len(userId)) --drop the -
+		-- end
+
+		userId = tonumber(userId)
+
+		local player = game.Players:GetPlayerByUserId(userId)
+		local description
+		if StarterPlayer.LoadCharacterAppearance then
+			description = game.Players:GetHumanoidDescriptionFromUserId(player.CharacterAppearanceId)
+		else
+			description = game.ReplicatedStorage:WaitForChild("DefaultDescription")
+		end
+		local dC = description:Clone()
+		srcModel = game:GetService("Players"):CreateHumanoidModelFromDescription(description, Enum.HumanoidRigType.R15)
+		
+		-- copy template humanoid to player
+		local h = srcModel:WaitForChild("Humanoid")
+		h.DisplayDistanceType = Enum.HumanoidDisplayDistanceType.None
+		h:ClearAllChildren()
+		dC.Parent = h
+		for _, item in source.template:FindFirstChild("Humanoid"):GetChildren() do
+			item:Clone().Parent = h
+		end
+
+		srcModel.Parent = game.Lighting
+		srcModel.Name = tostring(userId)
+		h.DisplayName = player.DisplayName
+	end)
+
+	if (result == false) then
+		warn("Loading " .. userId .. ":" ..err)
+	elseif srcModel then
+
+		local hip = (srcModel.HumanoidRootPart.Size.y
+				* 0.5) +srcModel.Humanoid.hipHeight
+
+		local data = { 
+			model =	srcModel, 
+			modelOffset = Vector3.yAxis * (hip - 2.55)
+		}
+
+		return data
+	end
+end
 
 
 return module
-

--- a/example/customclient/Characters/utils/MoveTypeWalking.luau
+++ b/example/customclient/Characters/utils/MoveTypeWalking.luau
@@ -1,0 +1,233 @@
+local module = {}
+local path = game.ReplicatedStorage.Shared.Chickynoid
+local MathUtils = require(path.Simulation.MathUtils)
+local Enums = require(path.Enums)
+
+function module:Setup(simulation)
+    self:ModifySimulation(simulation)
+end
+
+function module:ModifySimulation(simulation)
+    simulation:RegisterMoveState("Walking", self.ActiveThink, nil, nil, nil)
+    simulation:SetMoveState("Walking")
+
+    simulation.state.up = Vector3.yAxis
+end
+
+function module:ActiveThink(cmd)
+    --Check ground
+    local onGround = nil
+    onGround = self:DoGroundCheck(self.state.pos)
+
+    --If the player is on too steep a slope, its not ground
+	if (onGround ~= nil and onGround.normal.Y < self.constants.maxGroundSlope) then
+		
+		--See if we can move downwards?
+		if (self.state.vel.y < 0.1) then
+			local stuck = self:CheckGroundSlopes(self.state.pos)
+			
+			if (stuck == false) then
+				--we moved, that means the player is on a slope and can free fall
+				onGround = nil
+			else
+				--we didn't move, it means the ground we're on is sloped, but we can't fall any further
+				--treat it like flat ground
+				onGround.normal = Vector3.new(0,1,0)
+			end
+		else
+			onGround = nil
+		end
+	end
+	
+	 
+    --Mark if we were onground at the start of the frame
+    local startedOnGround = onGround
+	
+	--Simplify - whatever we are at the start of the frame goes.
+	self.lastGround = onGround
+	
+
+    --Did the player have a movement request?
+    local wishDir = nil
+    if cmd.x ~= 0 or cmd.z ~= 0 then
+        wishDir = Vector3.new(cmd.x, 0, cmd.z).Unit
+        self.state.pushDir = Vector2.new(cmd.x, cmd.z)
+    else
+        self.state.pushDir = Vector2.new(0, 0)
+    end
+
+    --Create flat velocity to operate our input command on
+    --In theory this should be relative to the ground plane instead...
+    local flatVel = MathUtils:FlatVec(self.state.vel)
+
+    --Does the player have an input?
+    if wishDir ~= nil then
+        if onGround then
+            --Moving along the ground under player input
+
+            flatVel = MathUtils:GroundAccelerate(
+                wishDir,
+                self.constants.maxSpeed,
+                self.constants.accel,
+                flatVel,
+                cmd.deltaTime
+            )
+
+            --Good time to trigger our walk anim
+            if self.state.pushing > 0 then
+                self.characterData:PlayAnimation(Enums.Anims.Push, Enums.AnimChannel.Channel0, false)
+            else
+                self.characterData:PlayAnimation(Enums.Anims.Walk, Enums.AnimChannel.Channel0, false)
+            end
+        else
+            --Moving through the air under player control
+            flatVel = MathUtils:Accelerate(wishDir, self.constants.airSpeed, self.constants.airAccel, flatVel, cmd.deltaTime)
+        end
+    else
+        if onGround ~= nil then
+            --Just standing around
+            flatVel = MathUtils:VelocityFriction(flatVel, self.constants.brakeFriction, cmd.deltaTime)
+
+            --Enter idle
+            self.characterData:PlayAnimation(Enums.Anims.Idle, Enums.AnimChannel.Channel0, false)
+        -- else
+            --moving through the air with no input
+        end
+    end
+
+    --Turn out flatvel back into our vel
+    self.state.vel = Vector3.new(flatVel.x, self.state.vel.y, flatVel.z)
+
+    --Do jumping?
+    if self.state.jump > 0 then
+        self.state.jump -= cmd.deltaTime
+        if self.state.jump < 0 then
+            self.state.jump = 0
+        end
+    end
+
+    if onGround ~= nil then
+        --jump!
+        if cmd.y > 0 and self.state.jump <= 0 then
+            self.state.vel = Vector3.new(self.state.vel.x, self.constants.jumpPunch, self.state.vel.z)
+            self.state.jump = 0.2 --jumping has a cooldown (think jumping up a staircase)
+            self.state.jumpThrust = self.constants.jumpThrustPower
+            self.characterData:PlayAnimation(Enums.Anims.Jump, Enums.AnimChannel.Channel0, true, 0.2)
+        end
+
+        --Check jumpPads
+        if onGround.hullRecord then
+            local instance = onGround.hullRecord.instance
+
+            if instance then
+                local vec3 = instance:GetAttribute("launch")
+                if vec3 then
+                    local dir = instance.CFrame:VectorToWorldSpace(vec3)
+                    self.state.vel = dir
+                    self.state.jump = 0.2
+                    self.characterData:PlayAnimation(Enums.Anims.Jump, Enums.AnimChannel.Channel0, true, 0.2)
+                end
+            end
+        end
+    end
+
+    --In air?
+    if onGround == nil then
+        self.state.inAir += cmd.deltaTime
+        if self.state.inAir > 10 then
+            self.state.inAir = 10 --Capped just to keep the state var reasonable
+        end
+
+        --Jump thrust
+        if cmd.y > 0 then
+            if self.state.jumpThrust > 0 then
+                self.state.vel += Vector3.new(0, self.state.jumpThrust * cmd.deltaTime, 0)
+                self.state.jumpThrust = MathUtils:Friction(
+                    self.state.jumpThrust,
+                    self.constants.jumpThrustDecay,
+                    cmd.deltaTime
+                )
+            end
+            if self.state.jumpThrust < 0.001 then
+                self.state.jumpThrust = 0
+            end
+        else
+            self.state.jumpThrust = 0
+        end
+
+        --gravity
+        self.state.vel += Vector3.new(0, self.constants.gravity * cmd.deltaTime, 0)
+
+        --Switch to falling if we've been off the ground for a bit
+        if self.state.vel.y <= 0.01 and self.state.inAir > 0.5 then
+            self.characterData:PlayAnimation(Enums.Anims.Fall, Enums.AnimChannel.Channel0, false)
+        end
+    else
+        self.state.inAir = 0
+    end
+
+    --Sweep the player through the world, once flat along the ground, and once "step up'd"
+    local stepUpResult = nil
+    local walkNewPos, walkNewVel, hitSomething = self:ProjectVelocity(self.state.pos, self.state.vel, cmd.deltaTime)
+
+    --Did we crashland
+    if onGround == nil and hitSomething == true then
+        --Land after jump
+        local groundCheck = self:DoGroundCheck(walkNewPos)
+
+        if groundCheck ~= nil then
+            --Crashland
+            walkNewVel = self:CrashLand(walkNewVel, cmd, groundCheck)
+        end
+    end
+
+    -- Do we attempt a stepup?                              (not jumping!)
+    if onGround ~= nil and hitSomething == true and self.state.jump == 0 then
+        stepUpResult = self:DoStepUp(self.state.pos, self.state.vel, cmd.deltaTime)
+    end
+
+    --Choose which one to use, either the original move or the stepup
+    if stepUpResult ~= nil then
+        self.state.stepUp += stepUpResult.stepUp
+        self.state.pos = stepUpResult.pos
+        self.state.vel = stepUpResult.vel
+    else
+        self.state.pos = walkNewPos
+        self.state.vel = walkNewVel
+    end
+
+    --Do stepDown
+    if true then
+        if startedOnGround ~= nil and self.state.jump == 0 and self.state.vel.y <= 0 then
+            local stepDownResult = self:DoStepDown(self.state.pos)
+            if stepDownResult ~= nil then
+                self.state.stepUp += stepDownResult.stepDown
+                self.state.pos = stepDownResult.pos
+            end
+        end
+    end
+
+    --Do angles
+    if (self.constants.aimlock == 1) then
+        
+        if (cmd.fa) then
+            local vec = cmd.fa - self.state.pos
+
+			self.state.targetAngle  = MathUtils:PlayerVecToAngle(vec)
+			self.state.angle = MathUtils:LerpAngle(
+				self.state.angle,
+				self.state.targetAngle,
+				self.constants.turnSpeedFrac * cmd.deltaTime
+			)
+        end
+    else    
+        if wishDir ~= nil then
+            self.state.targetAngle = MathUtils:PlayerVecToAngle(wishDir)
+            self.state.angle = MathUtils:LerpAngle(
+                self.state.angle,
+                self.state.targetAngle,
+                self.constants.turnSpeedFrac * cmd.deltaTime
+            )
+        end
+    end
+end

--- a/src/Client/CharacterModel/init.lua
+++ b/src/Client/CharacterModel/init.lua
@@ -1,4 +1,11 @@
+local Players = game:GetService("Players")
+local LocalPlayer = Players.LocalPlayer
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local RunService = game:GetService("RunService")
 local CharacterModel = {}
+
+local Janitor = require(ReplicatedStorage.Packages.Janitor)
+
 CharacterModel.__index = CharacterModel
 
 --[=[
@@ -8,8 +15,8 @@ CharacterModel.__index = CharacterModel
     Represents the client side view of a character model
     the local player and all other players get one of these each
     Todo: think about allowing a serverside version of this to exist for perhaps querying rays against?
-    
-    Consumes a CharacterData 
+
+    Consumes a CharacterData
 ]=]
 
 local path = script.Parent.Parent
@@ -20,14 +27,17 @@ local ClientMods = require(path.Client.ClientMods)
 CharacterModel.template = nil
 CharacterModel.characterModelCallbacks = {}
 
-
 function CharacterModel:ModuleSetup()
-	self.template = path.Assets:FindFirstChild("R15Rig")
+	self.template = ReplicatedStorage.Assets:FindFirstChild("R15Rig")
 	self.modelPool = {}
 end
 
-
+local CAM_OVERRIDE = false
 function CharacterModel.new(userId, characterMod)
+	if not characterMod then
+		warn("No character mod!!")
+	end
+
 	local self = setmetatable({
 		model = nil,
 		tracks = {},
@@ -35,19 +45,77 @@ function CharacterModel.new(userId, characterMod)
 		modelData = nil,
 		playingTrack = nil,
 		playingTrackNum = nil,
-		animCounter = -1,
+		animCounter0 = -1,
+		animCounter1 = -1,
+		animCounter2 = -1,
+		animCounter3 = -1,
 		modelOffset = Vector3.new(0, 0.5, 0),
 		modelReady = false,
-		startingAnimation = Enums.Anims.Idle,
+		startingAnimation = Enums.Anims.Stop,
+		startingSound = Enums.RootSounds.Stop,
 		userId = userId,
 		characterMod = characterMod,
 		mispredict = Vector3.new(0, 0, 0),
 		onModelCreated = FastSignal.new(),
 		onModelDestroyed = FastSignal.new(),
 
+		_cameraJanitor = Janitor.new()
+
 	}, CharacterModel)
 
+	if userId == LocalPlayer.UserId and CAM_OVERRIDE then
+		local camPart = Instance.new("Part")
+		camPart.Size = Vector3.one
+		camPart.Transparency = 1
+		camPart.Anchored = true
+		camPart.CanCollide = false
+		camPart.Name = tostring(userId) .. "_camPart"
+		camPart.Parent = workspace
+		self._camPart = camPart
+		self._camConnection = RunService.PostSimulation:Connect(function()
+			if self.model ~= nil then
+				camPart.CFrame = self.model:GetPivot()
+			end
+		end)
+
+		task.wait()
+		workspace.CurrentCamera.CameraSubject = camPart
+		workspace.CurrentCamera.CameraType = Enum.CameraType.Custom
+	end
 	return self
+end
+
+function CharacterModel:ChangeCharacterMod(mod)
+	print("changing character mod...")
+	self.characterMod = mod
+	-- save camera cframe
+	local camera = workspace.CurrentCamera
+	local cameraCf = camera.CFrame
+	-- task.wait()
+
+	if tonumber(self.userId) == game.Players.LocalPlayer.UserId then
+		camera.CameraType = Enum.CameraType.Scriptable
+	end
+
+	self:CreateModel()
+	task.wait()
+	if tonumber(self.userId) == game.Players.LocalPlayer.UserId and CAM_OVERRIDE then
+		local ZoomDistance = (cameraCf.Position - camera.Focus.Position).Magnitude
+		camera.CFrame = cameraCf
+		task.wait() -- ignore the task.waits, they're for camera manipulation things...
+
+		-- recovers the zoom (which is lost when you return the camera to "Custom")
+		local OldZoomMin = LocalPlayer.CameraMinZoomDistance
+		local OldZoomMax = LocalPlayer.CameraMaxZoomDistance
+		LocalPlayer.CameraMinZoomDistance = ZoomDistance
+		LocalPlayer.CameraMaxZoomDistance = ZoomDistance
+		LocalPlayer.CameraMinZoomDistance = OldZoomMin
+		LocalPlayer.CameraMaxZoomDistance = OldZoomMax
+
+		-- fall back to camera default
+
+		camera.CameraType = Enum.CameraType.Custom
+	end
 end
 
 function CharacterModel:CreateModel()
@@ -56,11 +124,11 @@ function CharacterModel:CreateModel()
 
 	--print("CreateModel ", self.userId)
 	coroutine.wrap(function()
+		local player = Players:GetPlayerByUserId(self.userId)
 
 		if (self.modelPool[self.userId] == nil) then
 
 			local srcModel = nil
-
 			-- Download custom character
 			for _, characterModelCallback in ipairs(self.characterModelCallbacks) do
 				local result = characterModelCallback(self.userId);
@@ -74,50 +142,21 @@ function CharacterModel:CreateModel()
 				if (self.characterMod) then
 					local loadedModule = ClientMods:GetMod("characters", self.characterMod)
 					if (loadedModule and loadedModule.GetCharacterModel) then
-						local template = loadedModule:GetCharacterModel(self.userId)
+						local template = loadedModule:GetCharacterModel(self.userId, self)
 						if (template) then
-							srcModel = template:Clone()
+							self.modelData = template
+							self.modelPool[self.userId] = template
+							print("got new template")
+						else
+							warn("Could not get character model for " .. self.characterMod)
 						end
 					end
 				end
 			end
-
-			if (srcModel == nil) then
-				srcModel = self.template:Clone()
-				srcModel.Parent = game.Lighting --needs to happen so loadAppearance works
-
-				local userId = ""
-				local result, err = pcall(function()
-
-					userId = self.userId
-
-					--Bot id?
-					if (string.sub(userId, 1, 1) == "-") then
-						userId = string.sub(userId, 2, string.len(userId)) --drop the -
-					end
-
-					local description = game.Players:GetHumanoidDescriptionFromUserId(userId)
-					srcModel.Humanoid:ApplyDescription(description)
-
-				end)
-				if (result == false) then
-					warn("Loading " .. userId .. ":" ..err)
-				end
-			end
-
-			--setup the hip
-			local hip = (srcModel.HumanoidRootPart.Size.y
-				* 0.5) +srcModel.Humanoid.hipHeight
-
-			self.modelData =  { 
-				model =	srcModel, 
-
-				modelOffset =  Vector3.new(0, hip - 2.5, 0)
-			}
-			self.modelPool[self.userId] = self.modelData
+		else
+			print("something bad happened...")
 		end
 
-		self.modelData = self.modelPool[self.userId]
 		self.model = self.modelData.model:Clone()
 		self.primaryPart = self.model.PrimaryPart
 		self.model.Parent = game.Lighting -- must happen to load animations		
@@ -140,10 +179,80 @@ function CharacterModel:CreateModel()
 			end
 		end
 
+		-- load RootPart sfx
+		self.rootSfx = {}
+		local sfxFolder = ReplicatedStorage.Assets.SFX.RootPart
+		for _, sfx : Sound in sfxFolder:GetChildren() do
+			local newSfx = sfx:Clone()
+			newSfx.Parent = self.model.PrimaryPart
+			self.rootSfx[newSfx.Name] = newSfx
+
+			local startTime = newSfx:GetAttribute("StartTime")
+			local endTime = newSfx:GetAttribute("EndTime")
+
+			-- custom time marker things
+			if startTime or endTime then
+				if newSfx.PlaybackRegionsEnabled then -- hopefully this goes live sometime soon
+					newSfx.PlaybackRegion.Min = startTime or 0
+					newSfx.PlaybackRegion.Max = endTime or 6000
+
+					if newSfx.Looped then
+						newSfx.LoopRegion.Min = startTime or 0
+						newSfx.LoopRegion.Max = endTime or 6000
+					end
+				else
+					-- legacy listeners
+					newSfx.TimePosition = startTime or 0
+					newSfx.Stopped:Connect(function()
+						newSfx.TimePosition = startTime or 0
+					end)
+
+					if newSfx.Looped and endTime then
+						newSfx:GetAttributeChangedSignal("TimePosition"):Connect(function()
+							if newSfx.TimePosition >= endTime then
+								newSfx.TimePosition = startTime or 0
+							end
+						end)
+					end
+				end
+			end
+		end
+
+		-- load particles to body parts
+		local srcParticles = ReplicatedStorage.Assets.Particles.Init
+		self.bodyParticles = {}
+		for _, bodyPart : BasePart in srcParticles:GetChildren() do
+			for _, particle : ParticleEmitter in bodyPart:GetChildren() do
+				if not self.bodyParticles[particle.Name] then
+					self.bodyParticles[particle.Name] = {}
+				end
+				local newParticle = particle:Clone()
+				newParticle.Parent = self.model:FindFirstChild(bodyPart.Name)
+
+				self.bodyParticles[particle.Name][bodyPart.Name] = newParticle
+			end
+		end
+
 		self.modelReady = true
-		self:PlayAnimation(self.startingAnimation, true)
+		self:PlayAnimation(self.startingAnimation, true, 0)
+		self:PlayRootSound(self.startingSound, true, 0)
+
 		self.model.Parent = game.Workspace
 		self.onModelCreated:Fire(self.model)
+		
+		if player == LocalPlayer then
+			local con
+			con = player.PlayerScripts.ChildAdded:Connect(function(c)
+				if c.Name == "RbxCharacterSounds" then
+					c:Destroy()
+					con:Disconnect()
+				end
+			end)
+			local sounds = player.PlayerScripts:FindFirstChild("RbxCharacterSounds")
+			if sounds then
+				sounds:Destroy()
+			end
+		end
 
 	end)()
 end
@@ -181,8 +290,8 @@ end
 
 
 --you shouldnt ever have to call this directly, change the characterData to trigger this
-function CharacterModel:PlayAnimation(enum, force)
-	local name = "Idle"
+function CharacterModel:PlayAnimation(enum, force, slot)
+	local name = "Stop"
 	for key, value in pairs(Enums.Anims) do
 		if value == enum then
 			name = key
@@ -198,18 +307,98 @@ function CharacterModel:PlayAnimation(enum, force)
 
 			local tracks = self.tracks
 			local track = tracks[name]
+			if enum == 0 then
+				if self["playingTrack" .. slot] then
+					self["playingTrack" .. slot]:Stop(0.1)
+					self["playingTrack" .. slot] = track
+				end
+				return
+			end
+			
 			if track then
-				if self.playingTrack ~= track or force == true then
-					for _, value in pairs(tracks) do
-						if value ~= track then
-							value:Stop(0.1)
-						end
+				if self["playingTrack" .. slot] ~= track or force == true then
+					if self["playingTrack" .. slot] ~= track and self["playingTrack" .. slot] ~= nil then
+						self["playingTrack" .. slot]:Stop(0.1)
 					end
+					
 					track:Play(0.1)
 
-					self.playingTrack = track
-					self.playingTrackNum = enum
+					self["playingTrack" .. slot] = track
+					-- self.playingTrackNum = enum
 				end
+			end
+		end
+	end
+end
+
+function CharacterModel:PlayRootSound(enum, force, slot)
+	local name = "Stop"
+	for key, value in pairs(Enums.RootSounds) do
+		if value == enum then
+			name = key
+			break
+		end
+	end
+
+	if self.modelReady == false then
+		self.startingSound = enum
+	else
+		if (self.modelData) then
+			local sounds = self.rootSfx
+			local sound : Sound = sounds[name]
+			if enum == 0 then
+				if self["playingSound" .. slot] then
+					self["playingSound" .. slot]:Stop()
+					self["playingSound" .. slot] = sound
+				end
+				return
+			end
+
+			if sound then
+				if self["playingSound" .. slot] ~= sound or force == true then
+					if self["playingSound" .. slot] ~= sound and self["playingSound" .. slot] ~= nil then
+						self["playingSound" .. slot]:Stop(0.1)
+					end
+
+					sound.TimePosition = sound:GetAttribute("StartTime") or 0
+					sound:Play()
+
+					self["playingSound" .. slot] = sound
+				end
+			else
+				warn("Could not find sound to play")
+			end
+		end
+	end
+end
+
+function CharacterModel:ToggleParticles(enum, slot, state)
+	local name = "Stop"
+	for key, value in pairs(Enums.Particles) do
+		if value == enum then
+			name = key
+			break
+		end
+	end
+
+	local particles = self.bodyParticles[name]
+	if enum == 0 then
+		if self["particles" .. slot] then
+			for _, p in self["particles" .. slot] do
+				p.Enabled = false
+			end
+		end
+		return
+	end
+
+	if self.modelReady then
+		if self.modelData then
+			if particles then
+				for _, p in particles do
+					p.Enabled = state or not p.Enabled
+				end
+
+				self["particles" .. slot] = particles
 			end
 		end
 	end
@@ -225,23 +414,47 @@ function CharacterModel:Think(_deltaTime, dataRecord, bulkMoveToList)
 	end
 
 	--Flag that something has changed
-	if self.animCounter ~= dataRecord.animCounter0 then
-		self.animCounter = dataRecord.animCounter0
-
-		self:PlayAnimation(dataRecord.animNum0, true)
+	for i = 0, 3 do
+		local counterString = "animCounter" .. i
+		local numString = "animNum" .. i
+		if self[counterString] ~= dataRecord[counterString] then
+			self[counterString] = dataRecord[counterString]
+	
+			self:PlayAnimation(dataRecord[numString], true, i)
+		end
 	end
 
-	if self.playingTrackNum == Enums.Anims.Run or self.playingTrackNum == Enums.Anims.Walk then
-		local vel = dataRecord.flatSpeed
-		local playbackSpeed = (vel / 16) --Todo: Persistant player stats
-		self.playingTrack:AdjustSpeed(playbackSpeed)
+	for i = 0, 3 do
+		local counterString = "soundCounter" .. i
+		local numString = "soundNum" .. i
+		if self[counterString] ~= dataRecord[counterString] then
+			self[counterString] = dataRecord[counterString]
+	
+			self:PlayRootSound(dataRecord[numString], true, i)
+		end
 	end
 
-	if self.playingTrackNum == Enums.Anims.Push then
-		local vel = 14
-		local playbackSpeed = (vel / 16) --Todo: Persistant player stats
-		self.playingTrack:AdjustSpeed(playbackSpeed)
+	for i = 0, 1 do
+		local counterString = "particlesCounter" .. i
+		local numString = "particlesNum" .. i
+		if self[counterString] ~= dataRecord[counterString] then
+			self[counterString] = dataRecord[counterString]
+
+			self:ToggleParticles(dataRecord[numString], i)
+		end
 	end
+
+	-- if self.playingTrackNum == Enums.Anims.Run or self.playingTrackNum == Enums.Anims.Walk then
+	-- 	local vel = dataRecord.flatSpeed
+	-- 	local playbackSpeed = (vel / 16) --Todo: Persistant player stats
+	-- 	self.playingTrack:AdjustSpeed(playbackSpeed)
+	-- end
+
+	-- if self.playingTrackNum == Enums.Anims.Push then
+	-- 	local vel = 14
+	-- 	local playbackSpeed = (vel / 16) --Todo: Persistant player stats
+	-- 	self.playingTrack:AdjustSpeed(playbackSpeed)
+	-- end
 
 
 	--[[
@@ -257,8 +470,8 @@ function CharacterModel:Think(_deltaTime, dataRecord, bulkMoveToList)
         return
     end]]--
 
-	local newCF = CFrame.new(dataRecord.pos + self.modelData.modelOffset + self.mispredict + Vector3.new(0, dataRecord.stepUp, 0))
-		* CFrame.fromEulerAnglesXYZ(0, dataRecord.angle, 0)
+	local newCF = CFrame.new(dataRecord.pos + self.modelData.modelOffset + self.mispredict)
+		* CFrame.fromOrientation(dataRecord.angleX, dataRecord.angle, dataRecord.angleZ)
 
 	if (bulkMoveToList) then
 		table.insert(bulkMoveToList.parts, self.primaryPart)

--- a/src/Client/CharacterModel/init.lua
+++ b/src/Client/CharacterModel/init.lua
@@ -153,6 +153,51 @@ function CharacterModel:CreateModel()
 					end
 				end
 			end
+
+			-- fallback default character
+			if (srcModel == nil) then
+				local userId = self.userId
+				local result, err = pcall(function()
+					--Bot id?
+					if (string.sub(userId, 1, 1) == "-") then
+						userId = string.sub(userId, 2, string.len(userId)) --drop the -
+					end
+			
+					userId = tonumber(userId)
+			
+					local player = game.Players:GetPlayerByUserId(userId)
+					local description
+					if StarterPlayer.LoadCharacterAppearance then
+						description = game.Players:GetHumanoidDescriptionFromUserId(player.CharacterAppearanceId)
+					else
+						description = game.ReplicatedStorage:WaitForChild("DefaultDescription")
+					end
+					local dC = description:Clone()
+					srcModel = game:GetService("Players"):CreateHumanoidModelFromDescription(description, Enum.HumanoidRigType.R15)
+					local humanoid = srcModel:WaitForChild("Humanoid")
+					dC.Parent = humanoid
+			
+					srcModel.Parent = game.Lighting
+					srcModel.Name = tostring(userId)
+					humanoid.DisplayName = player.DisplayName
+				end)
+			
+				if (result == false) then
+					warn("Loading " .. userId .. ":" ..err)
+				elseif srcModel then
+			
+					local hip = (srcModel.HumanoidRootPart.Size.y
+							* 0.5) +srcModel.Humanoid.hipHeight
+			
+					local data = { 
+						model =	srcModel, 
+						modelOffset = Vector3.yAxis * (hip - 2.55)
+					}
+			
+					return data
+				end
+			end
+
 		else
 			print("something bad happened...")
 		end

--- a/src/Server/InitPlayerRecord.lua
+++ b/src/Server/InitPlayerRecord.lua
@@ -39,7 +39,7 @@ function module:Setup(_server)
 		return false
 	end
 	
-	-- create a binding to call this elsewhere i.e. from the client using RbxUtil/Comm (https://sleitnick.github.io/RbxUtil/api/Comm/)
+	-- create a binding to call ToggleMoveset elsewhere i.e. from the client using RbxUtil/Comm (https://sleitnick.github.io/RbxUtil/api/Comm/)
 	--[[
 		local ChickynoidComm = ServerComm.new(game.ReplicatedStorage:WaitForChild("Comms"), "ChickynoidComm")
 		ChickynoidComm:BindFunction("ToggleMoveset", ToggleMoveset)

--- a/src/Server/InitPlayerRecord.lua
+++ b/src/Server/InitPlayerRecord.lua
@@ -1,0 +1,50 @@
+--[=[
+    @class InitCharacter
+    @server
+
+    Initialize new player records and connect them with character mod hotswap example
+]=]
+
+local Packages = game.ReplicatedStorage.Packages
+local ServerComm = require(Packages.Comm).ServerComm
+local ChickynoidComm = ServerComm.new(game.ReplicatedStorage:WaitForChild("Comms"), "ChickynoidComm")
+
+local module = {}
+
+function module:Setup(_server)
+	local initialized = {}
+
+	local function initPlayerRecord(serv, playerRecord)
+		if initialized[playerRecord.userId] == nil then
+			playerRecord:SetCharacterMod("NicerHumanoid")
+			initialized[playerRecord.userId] = playerRecord
+			print("initialized with characterMod", playerRecord.characterMod)
+		end
+		print("init playerRecord")
+	end
+
+	_server.OnPlayerConnected:Connect(initPlayerRecord)
+
+	-- init already connected players
+	for _, playerRecord in _server:GetPlayers() do
+		initPlayerRecord(_server, playerRecord)
+	end
+
+	local function ToggleMoveset(player: Player)
+		local playerRecord = initialized[player.UserId]
+		if playerRecord then
+			if playerRecord.characterMod == "NicerHumanoid" then
+				playerRecord:SetCharacterMod("ChickynoidHumanoid")
+			else
+				playerRecord:SetCharacterMod("NicerHumanoid")
+			end
+			print("swapping characterMod to", playerRecord.characterMod)
+			return true
+		end
+		return false
+	end
+	
+	ChickynoidComm:BindFunction("ToggleMoveset", ToggleMoveset)
+end
+
+return module

--- a/src/Server/InitPlayerRecord.lua
+++ b/src/Server/InitPlayerRecord.lua
@@ -4,11 +4,6 @@
 
     Initialize new player records and connect them with character mod hotswap example
 ]=]
-
-local Packages = game.ReplicatedStorage.Packages
-local ServerComm = require(Packages.Comm).ServerComm
-local ChickynoidComm = ServerComm.new(game.ReplicatedStorage:WaitForChild("Comms"), "ChickynoidComm")
-
 local module = {}
 
 function module:Setup(_server)
@@ -44,7 +39,11 @@ function module:Setup(_server)
 		return false
 	end
 	
-	ChickynoidComm:BindFunction("ToggleMoveset", ToggleMoveset)
+	-- create a binding to call this elsewhere i.e. from the client using RbxUtil/Comm (https://sleitnick.github.io/RbxUtil/api/Comm/)
+	--[[
+		local ChickynoidComm = ServerComm.new(game.ReplicatedStorage:WaitForChild("Comms"), "ChickynoidComm")
+		ChickynoidComm:BindFunction("ToggleMoveset", ToggleMoveset)
+	]]
 end
 
 return module

--- a/src/Server/init.lua
+++ b/src/Server/init.lua
@@ -20,6 +20,7 @@ local DeltaTable = require(path.Vendor.DeltaTable)
 local WeaponsModule = require(script.WeaponsServer)
 local CollisionModule = require(path.Simulation.CollisionModule)
 local Antilag = require(path.Server.Antilag)
+local InitPlayerRecord = require(path.Server.InitPlayerRecord)
 local FastSignal = require(path.Vendor.FastSignal)
 local ServerMods = require(script.ServerMods)
 
@@ -44,7 +45,7 @@ ChickynoidServer.startTime = tick()
 ChickynoidServer.slots = {}
 ChickynoidServer.collisionRootFolder = nil
 
-ChickynoidServer.playerSize = Vector3.new(2, 5, 2)
+ChickynoidServer.playerSize = Vector3.new(3, 5, 3)
 
 --[=[
 	@interface ServerConfig
@@ -117,6 +118,7 @@ function ChickynoidServer:Setup()
     WeaponsModule:Setup(self)
 
     Antilag:Setup(self)
+    InitPlayerRecord:Setup(self)
 
     --Load the mods
     local modules = ServerMods:GetMods("servermods")
@@ -182,7 +184,7 @@ function ChickynoidServer:AddConnection(userId, player)
 
     playerRecord.OnBeforePlayerSpawn = FastSignal.new()
 
-    playerRecord.characterMod = "HumanoidChickynoid"
+    playerRecord.characterMod = "NicerHumanoid"
 	playerRecord.lastSeenFrames = {} --frame we last saw a given player on, for delta compression
 		
 	local assignedSlot = self:AssignSlot(playerRecord)
@@ -263,6 +265,17 @@ function ChickynoidServer:AddConnection(userId, player)
 
     function playerRecord:SetCharacterMod(characterModName)
 		self.characterMod = characterModName
+        if self.chickynoid then
+            if self.chickynoid.simulation then
+                -- find new mod and apply settings
+                local loadedModule = ServerMods:GetMod("characters", self.characterMod)
+                if (loadedModule) then
+                    loadedModule:Setup(self.chickynoid.simulation)
+                    print("setup new stats")
+                end
+            end
+        end
+
 		ChickynoidServer:SetWorldStateDirty()
     end
 

--- a/src/Simulation/init.lua
+++ b/src/Simulation/init.lua
@@ -37,6 +37,7 @@ function Simulation.new(userId)
     self.state.jumpThrust = 0
     self.state.pushing = 0 --External flag comes from server (ungh >_<')
     self.state.moveState = 0 --Walking!
+    
 
     self.characterData = CharacterData.new()
 
@@ -53,17 +54,15 @@ function Simulation.new(userId)
     self.constants.runFriction = 0.01 --friction applied after max speed
     self.constants.brakeFriction = 0.02 --Lower is brake harder, dont use 0
     self.constants.maxGroundSlope = 0.05 --about 89o
-    self.constants.jumpThrustPower = 0    --No variable height jumping 
+    self.constants.jumpThrustPower = 0    --No variable height jumping
     self.constants.jumpThrustDecay = 0
 	self.constants.gravity = -198
 	self.constants.crashLandBehavior = Enums.Crashland.FULL_BHOP_FORWARD
 
     self.constants.pushSpeed = 16 --set this lower than maxspeed if you want stuff to feel heavy
-	self.constants.stepSize = 2.2
+	self.constants.stepSize = 2.9
 	self.constants.gravity = -198
 
-    self:RegisterMoveState("Walking", self.MovetypeWalking, nil, nil, nil)
-    self:SetMoveState("Walking")
     return self
 end
 
@@ -155,6 +154,7 @@ function Simulation:ProcessCommand(cmd)
     --Write this to the characterData
     self.characterData:SetTargetPosition(self.state.pos)
     self.characterData:SetAngle(self.state.angle)
+
     self.characterData:SetStepUp(self.state.stepUp)
     self.characterData:SetFlatSpeed( MathUtils:FlatVec(self.state.vel).Magnitude)
 
@@ -170,7 +170,7 @@ function Simulation:SetAngle(angle, teleport)
 end
 
 function Simulation:SetPosition(position, teleport)
-    self.state.position = position
+    self.state.pos = position
     self.characterData:SetTargetPosition(self.state.pos, teleport)
 end
 
@@ -233,6 +233,7 @@ end
 --STEPUP - the magic that lets us traverse uneven world geometry
 --the idea is that you redo the player movement but "if I was x units higher in the air"
 
+-- TODO: Change to only apply our smooth rolling on non-walking movesets ("NicerHumanoid" characterMod)
 function Simulation:DoStepUp(pos, vel, deltaTime)
     local flatVel = MathUtils:FlatVec(vel)
 
@@ -246,7 +247,7 @@ function Simulation:DoStepUp(pos, vel, deltaTime)
 
     --Trace back down
     local traceDownPos = stepUpNewPos
-    local hitResult = CollisionModule:Sweep(traceDownPos, traceDownPos - stepVec)
+    local hitResult = CollisionModule:Sweep(traceDownPos, traceDownPos - Vector3.new(0, self.constants.aggressiveStep, 0))
 
     stepUpNewPos = hitResult.endPos
 
@@ -283,7 +284,6 @@ function Simulation:DoStepDown(pos)
         and hitResult.normal.Y >= self.constants.maxGroundSlope
     then
         local delta = pos.y - hitResult.endPos.y
-
         if delta > 0.001 then
             local result = {
 
@@ -480,227 +480,6 @@ function Simulation:GetStandingPart()
         return self.lastGround.hullRecord.instance
     end
     return nil
-end
-
-
---Move me to my own file!
-function Simulation:MovetypeWalking(cmd)
-
-    --Check ground
-    local onGround = nil
-    onGround = self:DoGroundCheck(self.state.pos)
-
-    --If the player is on too steep a slope, its not ground
-	if (onGround ~= nil and onGround.normal.Y < self.constants.maxGroundSlope) then
-		
-		--See if we can move downwards?
-		if (self.state.vel.y < 0.1) then
-			local stuck = self:CheckGroundSlopes(self.state.pos)
-			
-			if (stuck == false) then
-				--we moved, that means the player is on a slope and can free fall
-				onGround = nil
-			else
-				--we didn't move, it means the ground we're on is sloped, but we can't fall any further
-				--treat it like flat ground
-				onGround.normal = Vector3.new(0,1,0)
-			end
-		else
-			onGround = nil
-		end
-	end
-	
-	 
-    --Mark if we were onground at the start of the frame
-    local startedOnGround = onGround
-	
-	--Simplify - whatever we are at the start of the frame goes.
-	self.lastGround = onGround
-	
-
-    --Did the player have a movement request?
-    local wishDir = nil
-    if cmd.x ~= 0 or cmd.z ~= 0 then
-        wishDir = Vector3.new(cmd.x, 0, cmd.z).Unit
-        self.state.pushDir = Vector2.new(cmd.x, cmd.z)
-    else
-        self.state.pushDir = Vector2.new(0, 0)
-    end
-
-    --Create flat velocity to operate our input command on
-    --In theory this should be relative to the ground plane instead...
-    local flatVel = MathUtils:FlatVec(self.state.vel)
-
-    --Does the player have an input?
-    if wishDir ~= nil then
-        if onGround then
-            --Moving along the ground under player input
-
-            flatVel = MathUtils:GroundAccelerate(
-                wishDir,
-                self.constants.maxSpeed,
-                self.constants.accel,
-                flatVel,
-                cmd.deltaTime
-            )
-
-            --Good time to trigger our walk anim
-            if self.state.pushing > 0 then
-                self.characterData:PlayAnimation(Enums.Anims.Push, Enums.AnimChannel.Channel0, false)
-            else
-                self.characterData:PlayAnimation(Enums.Anims.Walk, Enums.AnimChannel.Channel0, false)
-            end
-        else
-            --Moving through the air under player control
-            flatVel = MathUtils:Accelerate(wishDir, self.constants.airSpeed, self.constants.airAccel, flatVel, cmd.deltaTime)
-        end
-    else
-        if onGround ~= nil then
-            --Just standing around
-            flatVel = MathUtils:VelocityFriction(flatVel, self.constants.brakeFriction, cmd.deltaTime)
-
-            --Enter idle
-            self.characterData:PlayAnimation(Enums.Anims.Idle, Enums.AnimChannel.Channel0, false)
-        -- else
-            --moving through the air with no input
-        end
-    end
-
-    --Turn out flatvel back into our vel
-    self.state.vel = Vector3.new(flatVel.x, self.state.vel.y, flatVel.z)
-
-    --Do jumping?
-    if self.state.jump > 0 then
-        self.state.jump -= cmd.deltaTime
-        if self.state.jump < 0 then
-            self.state.jump = 0
-        end
-    end
-
-    if onGround ~= nil then
-        --jump!
-        if cmd.y > 0 and self.state.jump <= 0 then
-            self.state.vel = Vector3.new(self.state.vel.x, self.constants.jumpPunch, self.state.vel.z)
-            self.state.jump = 0.2 --jumping has a cooldown (think jumping up a staircase)
-            self.state.jumpThrust = self.constants.jumpThrustPower
-            self.characterData:PlayAnimation(Enums.Anims.Jump, Enums.AnimChannel.Channel0, true, 0.2)
-        end
-
-        --Check jumpPads
-        if onGround.hullRecord then
-            local instance = onGround.hullRecord.instance
-
-            if instance then
-                local vec3 = instance:GetAttribute("launch")
-                if vec3 then
-                    local dir = instance.CFrame:VectorToWorldSpace(vec3)
-                    self.state.vel = dir
-                    self.state.jump = 0.2
-                    self.characterData:PlayAnimation(Enums.Anims.Jump, Enums.AnimChannel.Channel0, true, 0.2)
-                end
-            end
-        end
-    end
-
-    --In air?
-    if onGround == nil then
-        self.state.inAir += cmd.deltaTime
-        if self.state.inAir > 10 then
-            self.state.inAir = 10 --Capped just to keep the state var reasonable
-        end
-
-        --Jump thrust
-        if cmd.y > 0 then
-            if self.state.jumpThrust > 0 then
-                self.state.vel += Vector3.new(0, self.state.jumpThrust * cmd.deltaTime, 0)
-                self.state.jumpThrust = MathUtils:Friction(
-                    self.state.jumpThrust,
-                    self.constants.jumpThrustDecay,
-                    cmd.deltaTime
-                )
-            end
-            if self.state.jumpThrust < 0.001 then
-                self.state.jumpThrust = 0
-            end
-        else
-            self.state.jumpThrust = 0
-        end
-
-        --gravity
-        self.state.vel += Vector3.new(0, self.constants.gravity * cmd.deltaTime, 0)
-
-        --Switch to falling if we've been off the ground for a bit
-        if self.state.vel.y <= 0.01 and self.state.inAir > 0.5 then
-            self.characterData:PlayAnimation(Enums.Anims.Fall, Enums.AnimChannel.Channel0, false)
-        end
-    else
-        self.state.inAir = 0
-    end
-
-    --Sweep the player through the world, once flat along the ground, and once "step up'd"
-    local stepUpResult = nil
-    local walkNewPos, walkNewVel, hitSomething = self:ProjectVelocity(self.state.pos, self.state.vel, cmd.deltaTime)
-
-    --Did we crashland
-    if onGround == nil and hitSomething == true then
-        --Land after jump
-        local groundCheck = self:DoGroundCheck(walkNewPos)
-
-        if groundCheck ~= nil then
-            --Crashland
-            walkNewVel = self:CrashLand(walkNewVel, cmd, groundCheck)
-        end
-    end
-
-    -- Do we attempt a stepup?                              (not jumping!)
-    if onGround ~= nil and hitSomething == true and self.state.jump == 0 then
-        stepUpResult = self:DoStepUp(self.state.pos, self.state.vel, cmd.deltaTime)
-    end
-
-    --Choose which one to use, either the original move or the stepup
-    if stepUpResult ~= nil then
-        self.state.stepUp += stepUpResult.stepUp
-        self.state.pos = stepUpResult.pos
-        self.state.vel = stepUpResult.vel
-    else
-        self.state.pos = walkNewPos
-        self.state.vel = walkNewVel
-    end
-
-    --Do stepDown
-    if true then
-        if startedOnGround ~= nil and self.state.jump == 0 and self.state.vel.y <= 0 then
-            local stepDownResult = self:DoStepDown(self.state.pos)
-            if stepDownResult ~= nil then
-                self.state.stepUp += stepDownResult.stepDown
-                self.state.pos = stepDownResult.pos
-            end
-        end
-    end
-
-    --Do angles
-    if (self.constants.aimlock == 1) then
-        
-        if (cmd.fa) then
-            local vec = cmd.fa - self.state.pos
-
-			self.state.targetAngle  = MathUtils:PlayerVecToAngle(vec)
-			self.state.angle = MathUtils:LerpAngle(
-				self.state.angle,
-				self.state.targetAngle,
-				self.constants.turnSpeedFrac * cmd.deltaTime
-			)
-        end
-    else    
-        if wishDir ~= nil then
-            self.state.targetAngle = MathUtils:PlayerVecToAngle(wishDir)
-            self.state.angle = MathUtils:LerpAngle(
-                self.state.angle,
-                self.state.targetAngle,
-                self.constants.turnSpeedFrac * cmd.deltaTime
-            )
-        end
-    end
 end
 
 return Simulation

--- a/src/Simulation/init.lua
+++ b/src/Simulation/init.lua
@@ -60,7 +60,7 @@ function Simulation.new(userId)
 	self.constants.crashLandBehavior = Enums.Crashland.FULL_BHOP_FORWARD
 
     self.constants.pushSpeed = 16 --set this lower than maxspeed if you want stuff to feel heavy
-	self.constants.stepSize = 2.9
+	self.constants.stepSize = 2.2
 	self.constants.gravity = -198
 
     return self


### PR DESCRIPTION
Before this change, calling `playerRecord:SetCharacterMod(characterModName)` after a character model has already been created and initialized did nothing but send a dirty world state. However, no visible changes were made with this new dirty world state. This aims to reflect new simulation constants and character models to the client and server when calling `SetCharacterMod`, allowing for the hotswapping of different simulation "settings" (`simulation.constants`) during gameplay. An example of this characterMod hotswap can be found in `Server\InitPlayerRecord.lua` where `local function ToggleMoveset()` will swap between two sets of constants, `HumanoidChickynoid` and `NicerHumanoid` which can be found in `example\customclient\Character`.

My current use case for this feature is to toggle between "roller skates" and "walking" simulation constants in real-time during gameplay. This also meant reconstructing the player model to utilize roller skate models attached to the character's feet with an added Y offset to account for them during movement. I found it underwhelming and misleading when I found that `playerRecord:SetCharacterMod()` didn't produce any visible changes out of the box. I don't know if this is the intended functionality of the method, but it was already very lightweight to begin.