### PR TITLE
Support multiple player sizes and dynamically changing them

### DIFF
--- a/example/customclient/Characters/NicerHumanoid.lua
+++ b/example/customclient/Characters/NicerHumanoid.lua
@@ -32,4 +32,3 @@ end
 
 
 return module
-

--- a/src/Simulation/CollisionModule.lua
+++ b/src/Simulation/CollisionModule.lua
@@ -745,7 +745,7 @@ function module:Sweep(startPos, endPos, playerSize)
 		data.checks += 1
 		
 		if (hullRecord.hull[playerSize] ~= nil) then
-	        self:CheckBrushNoStuck(data, hullRecord)
+	        self:CheckBrushNoStuck(data, hullRecord, playerSize)
 	        if data.allSolid == true then
 	            data.fraction = 0
 	            break
@@ -763,14 +763,15 @@ function module:Sweep(startPos, endPos, playerSize)
     if data.fraction >= SKIN_THICKNESS or data.allSolid == false then
         for _, hullRecord in pairs(self.dynamicRecords) do
             data.checks += 1
-
-            self:CheckBrushNoStuck(data, hullRecord)
-            if data.allSolid == true then
-                data.fraction = 0
-                break
-            end
-            if data.fraction < SKIN_THICKNESS then
-                break
+            if (hullRecord.hull[playerSize] ~= nil) then
+                self:CheckBrushNoStuck(data, hullRecord, playerSize)
+                if data.allSolid == true then
+                    data.fraction = 0
+                    break
+                end
+                if data.fraction < SKIN_THICKNESS then
+                    break
+                end
             end
         end
     end
@@ -786,7 +787,8 @@ function module:Sweep(startPos, endPos, playerSize)
     return data
 end
 
-function module:BoxTest(pos)
+function module:BoxTest(pos, playerSize)
+    playerSize = playerSize or module.expansionSize
     local data = {}
     data.startPos = pos
     data.endPos = pos
@@ -805,7 +807,7 @@ function module:BoxTest(pos)
 
     for _, hullRecord in pairs(hullRecords) do
         data.checks += 1
-        self:CheckBrushPoint(data, hullRecord)
+        self:CheckBrushPoint(data, hullRecord, playerSize)
         if data.allSolid == true then
             data.fraction = 0
             break

--- a/src/Simulation/CollisionModule.lua
+++ b/src/Simulation/CollisionModule.lua
@@ -255,7 +255,8 @@ function module:FetchHullsForPoint(point)
     return hullRecords
 end
 
-function module:FetchHullsForBox(min, max)
+function module:FetchHullsForBox(min, max, playerSize)
+    local fetchExpansionSize = playerSize or module.expansionSize
     local minx = min.x
     local miny = min.y
     local minz = min.z
@@ -347,13 +348,10 @@ function module:FetchHullsForBox(min, max)
 	
 	--Inflate missing hulls
 	for key,record in pairs(hullRecords) do
-       
     	if (record.hull == nil) then
-			record.hull = self:GenerateConvexHullAccurate(record.instance, module.expansionSize, self:GenerateSnappedCFrame(record.instance))
-            if (record.hull == nil) then
-                hullRecords[key] = nil
-            end
-		end
+            record.hull = {}
+        end
+		record.hull[fetchExpansionSize] = self:GenerateConvexHullAccurate(record.instance, fetchExpansionSize, self:GenerateSnappedCFrame(record.instance))
 	end
 	
 		
@@ -512,10 +510,10 @@ function module:SimpleRayTest(a, b, hull)
     return tfirst, tlast
 end
 
-function module:CheckBrushPoint(data, hullRecord)
+function module:CheckBrushPoint(data, hullRecord, playerSize)
     local startsOut = false
 
-    for _, p in pairs(hullRecord.hull) do
+    for _, p in pairs(hullRecord.hull[playerSize]) do
         local startDistance = data.startPos:Dot(p.n) - p.ed
 
         if startDistance > 0 then
@@ -534,14 +532,14 @@ function module:CheckBrushPoint(data, hullRecord)
 end
 
 --Checks a brush, but doesn't handle it well if the start point is inside a brush
-function module:CheckBrush(data, hullRecord)
+function module:CheckBrush(data, hullRecord, playerSize)
     local startFraction = -1.0
     local endFraction = 1.0
     local startsOut = false
     local endsOut = false
     local lastPlane = nil
 
-    for _, p in pairs(hullRecord.hull) do
+    for _, p in pairs(hullRecord.hull[playerSize]) do
         local startDistance = data.startPos:Dot(p.n) - p.ed
         local endDistance = data.endPos:Dot(p.n) - p.ed
 
@@ -608,7 +606,7 @@ function module:CheckBrush(data, hullRecord)
 end
 
 --Checks a brush, but is smart enough to ignore the brush entirely if the start point is inside but the ray is "exiting" or "exited"
-function module:CheckBrushNoStuck(data, hullRecord)
+function module:CheckBrushNoStuck(data, hullRecord, playerSize)
     local startFraction = -1.0
     local endFraction = 1.0
     local startsOut = false
@@ -618,7 +616,7 @@ function module:CheckBrushNoStuck(data, hullRecord)
     local nearestStart = -math.huge
     local nearestEnd = -math.huge
 	
-    for _, p in pairs(hullRecord.hull) do
+    for _, p in pairs(hullRecord.hull[playerSize]) do
         local startDistance = data.startPos:Dot(p.n) - p.ed
         local endDistance = data.endPos:Dot(p.n) - p.ed
 
@@ -711,7 +709,8 @@ function module:PlaneLineIntersect(normal, distance, V1, V2)
     return (V1 + u * (V2 - V1))
 end
 
-function module:Sweep(startPos, endPos)
+function module:Sweep(startPos, endPos, playerSize)
+    playerSize = playerSize or module.expansionSize
     local data = {}
     data.startPos = startPos
     data.endPos = endPos
@@ -734,7 +733,7 @@ function module:Sweep(startPos, endPos)
 	if (self.profile == true) then
 		debug.profilebegin("Fetch")
 	end
-    local hullRecords = self:FetchHullsForBox(startPos, endPos)
+    local hullRecords = self:FetchHullsForBox(startPos, endPos, playerSize)
 	if (self.profile==true) then
 		debug.profileend()
 	end
@@ -745,7 +744,7 @@ function module:Sweep(startPos, endPos)
     for _, hullRecord in pairs(hullRecords) do
 		data.checks += 1
 		
-		if (hullRecord.hull ~= nil) then
+		if (hullRecord.hull[playerSize] ~= nil) then
 	        self:CheckBrushNoStuck(data, hullRecord)
 	        if data.allSolid == true then
 	            data.fraction = 0

--- a/src/Simulation/init.lua
+++ b/src/Simulation/init.lua
@@ -37,7 +37,7 @@ function Simulation.new(userId)
     self.state.jumpThrust = 0
     self.state.pushing = 0 --External flag comes from server (ungh >_<')
     self.state.moveState = 0 --Walking!
-    
+    self.state.playerSize = Vector3.new(3, 5, 3)
 
     self.characterData = CharacterData.new()
 
@@ -240,14 +240,14 @@ function Simulation:DoStepUp(pos, vel, deltaTime)
     local stepVec = Vector3.new(0, self.constants.stepSize, 0)
     --first move upwards as high as we can go
 
-    local headHit = CollisionModule:Sweep(pos, pos + stepVec)
+    local headHit = CollisionModule:Sweep(pos, pos + stepVec, self.state.playerSize)
 
     --Project forwards
     local stepUpNewPos, stepUpNewVel, _stepHitSomething = self:ProjectVelocity(headHit.endPos, flatVel, deltaTime)
 
     --Trace back down
     local traceDownPos = stepUpNewPos
-    local hitResult = CollisionModule:Sweep(traceDownPos, traceDownPos - Vector3.new(0, self.constants.aggressiveStep, 0))
+    local hitResult = CollisionModule:Sweep(traceDownPos, traceDownPos - Vector3.new(0, self.constants.aggressiveStep, 0), self.state.playerSize)
 
     stepUpNewPos = hitResult.endPos
 
@@ -276,7 +276,7 @@ end
 --Magic to stick to the ground instead of falling on every stair
 function Simulation:DoStepDown(pos)
     local stepVec = Vector3.new(0, self.constants.stepSize, 0)
-    local hitResult = CollisionModule:Sweep(pos, pos - stepVec)
+    local hitResult = CollisionModule:Sweep(pos, pos - stepVec, self.state.playerSize)
 
     if
         hitResult.startSolid == false
@@ -308,7 +308,7 @@ function Simulation:DecayStepUp(deltaTime)
 end
 
 function Simulation:DoGroundCheck(pos)
-    local results = CollisionModule:Sweep(pos + Vector3.new(0, 0.1, 0), pos + Vector3.new(0, -0.1, 0))
+    local results = CollisionModule:Sweep(pos + Vector3.new(0, 0.1, 0), pos + Vector3.new(0, -0.1, 0), self.state.playerSize)
 
     if results.allSolid == true or results.startSolid == true then
         --We're stuck, pretend we're in the air
@@ -345,7 +345,7 @@ function Simulation:ProjectVelocity(startPos, startVel, deltaTime)
         end
 
         --We only operate on a scaled down version of velocity
-        local result = CollisionModule:Sweep(movePos, movePos + (moveVel * timeLeft))
+        local result = CollisionModule:Sweep(movePos, movePos + (moveVel * timeLeft), self.state.playerSize)
 
         --Update our position
         if result.fraction > 0 then
@@ -393,7 +393,7 @@ function Simulation:CheckGroundSlopes(startPos)
 	local moveDir = Vector3.new(0,-1,0)
 	
 	--We only operate on a scaled down version of velocity
-	local result = CollisionModule:Sweep(movePos, movePos + moveDir)
+	local result = CollisionModule:Sweep(movePos, movePos + moveDir, self.state.playerSize)
 
 	--Update our position
 	if result.fraction > 0 then
@@ -414,7 +414,7 @@ function Simulation:CheckGroundSlopes(startPos)
 	end
 	
 	--Try and move it
-	local result = CollisionModule:Sweep(movePos, movePos + moveDir)
+	local result = CollisionModule:Sweep(movePos, movePos + moveDir, self.state.playerSize)
 	if (result.fraction == 0) then
 		return true --stuck
 	end


### PR DESCRIPTION
Added a new playerSize field to default simulation state to dynamically pull new hulls based on different sizes, primarily heights. It's up to developers on how they want to implement this, but I've added an example in MoveTypeBase and GenerateCommand to support crouching. Resolving the character height offset is up to developers as well.