### PR TITLE
fix(rojo): should not bundle as datamodel

### DIFF
--- a/default.project.json
+++ b/default.project.json
@@ -1,7 +1,6 @@
 {
 	"name": "chickynoid",
 	"tree": {
-		"$className": "DataModel",
 		"$path": "src"
 	}
 }


### PR DESCRIPTION
I'm unable to sync w. rojo until this is fixed.