### PR TITLE
fix(collisions): do not check terrain

### DIFF
--- a/src/Simulation/CollisionModule.lua
+++ b/src/Simulation/CollisionModule.lua
@@ -845,14 +845,13 @@ function module:MakeWorld(folder, playerSize)
 
 	coroutine.wrap(function()
 		local list = folder:GetDescendants()
-		local total = #folder:GetDescendants()
+		local total = #list
 		
 		local lastTime = tick()
 		for counter = 1, total do		
 			local instance = list[counter]
-						
-			if (instance:IsA("BasePart") and instance.CanCollide == true) then
-						
+
+			if (instance:IsA("BasePart") and not instance:IsA("Terrain") and instance.CanCollide == true) then		
 				local begin = tick()
 				self:ProcessCollisionOnInstance(instance, playerSize)
 				local timeTaken = tick()- begin


### PR DESCRIPTION
Allows for `RecreateCollisions` to be set to Workspace
Use-case: my game has 171k parts (w. streamingenabled), putting it all into another folder would be a nightmare!