### PR TITLE
fix stop animation functions not working

### DIFF
--- a/src/Client/CharacterModel/init.lua
+++ b/src/Client/CharacterModel/init.lua
@@ -210,6 +210,10 @@ function CharacterModel:PlayAnimation(enum, force)
 					self.playingTrack = track
 					self.playingTrackNum = enum
 				end
+			else
+				for _, value in pairs(tracks) do
+					value:Stop(0.1)
+				end
 			end
 		end
 	end

--- a/src/Client/CharacterModel/init.lua
+++ b/src/Client/CharacterModel/init.lua
@@ -182,6 +182,15 @@ end
 
 --you shouldnt ever have to call this directly, change the characterData to trigger this
 function CharacterModel:PlayAnimation(enum, force)
+	local tracks = self.tracks
+
+	if enum == 0 then
+		for _, value in pairs(tracks) do
+			value:Stop(0.1)
+		end
+		return
+	end
+
 	local name = "Idle"
 	for key, value in pairs(Enums.Anims) do
 		if value == enum then
@@ -195,8 +204,6 @@ function CharacterModel:PlayAnimation(enum, force)
 		self.startingAnimation = enum
 	else
 		if (self.modelData) then
-
-			local tracks = self.tracks
 			local track = tracks[name]
 			if track then
 				if self.playingTrack ~= track or force == true then
@@ -209,10 +216,6 @@ function CharacterModel:PlayAnimation(enum, force)
 
 					self.playingTrack = track
 					self.playingTrackNum = enum
-				end
-			else
-				for _, value in pairs(tracks) do
-					value:Stop(0.1)
 				end
 			end
 		end


### PR DESCRIPTION
``CharacterData:StopAnimation`` and ``CharacterData:StopAllAnimation`` did not function properly as any playing animations were not stopped - the section responsible for doing this was skipped as ``Stop`` is not a valid animation name

I implemented a guard clause to stop all animations if the stop enum is inputted 