### PR TITLE
Clamping the serverTime commands can contain, to prevent lagging out the server

### DIFF
--- a/src/ServerScriptService/Packages/Chickynoid/Server/Bots.lua
+++ b/src/ServerScriptService/Packages/Chickynoid/Server/Bots.lua
@@ -100,7 +100,7 @@ function module:MakeBots(Server, numBots)
 			command.x = 0
 			command.y = 0
 			command.z = 0
-			command.serverTime = tick()
+			command.serverTime = Server.serverSimulationTime
 			command.deltaTime = deltaTime
 			
 			 

--- a/src/ServerScriptService/Packages/Chickynoid/Server/ServerChickynoid.lua
+++ b/src/ServerScriptService/Packages/Chickynoid/Server/ServerChickynoid.lua
@@ -136,8 +136,7 @@ function ServerChickynoid:GenerateFakeCommand(server, deltaTime)
 	local event = {}
 	event.t = EventType.Command
 	event.command = command
-	self:HandleClientUnreliableEvent(server, event, true)
-	
+	self:HandleClientUnreliableEvent(server, event, true)	
 	
 	self.debug.fakeCommandsThisSecond += 1
 end
@@ -287,6 +286,8 @@ function ServerChickynoid:ProcessCommand(server, command, fakeCommand, resent)
 		if command.serverTime == nil or typeof(command.serverTime) ~= "number" 	or command.serverTime ~= command.serverTime then
 			return
 		end
+
+		command.serverTime = math.clamp(command.serverTime, 0, server.serverSimulationTime)
 
 		if command.playerStateFrame == nil or typeof(command.playerStateFrame) ~= "number" or command.playerStateFrame ~= command.playerStateFrame then
 			return				


### PR DESCRIPTION
Clients can currently send whatever serverTime they wish in their commands. If a client repeatedly sends a number that's higher than the serverSimulationTime, the server lags out and the antilag module errors. 

I've simply clamped the serverTime received from players to prevent this, and changed the serverTime that bots send to be the serverSimulationTime instead of tick.
