### PR TITLE
fix unreliable remotes being dropped by EventType.State 

### DIFF
--- a/src/ServerScriptService/Packages/Chickynoid/Server/ServerChickynoid.lua
+++ b/src/ServerScriptService/Packages/Chickynoid/Server/ServerChickynoid.lua
@@ -422,13 +422,13 @@ function ServerChickynoid:ConstructPlayerStateDelta(serverFrame : number)
 	local currentState = self.simulation:WriteState()
 	if (self.lastSeenState == nil) then
 		self.storedStates[serverFrame] = DeltaTable:DeepCopy(currentState)
-		return currentState, nil
+		return currentState, nil, true
 	end
 	
 	--we have one!	
     local stateDelta = DeltaTable:MakeDeltaTable(self.lastSeenState, currentState)
 	self.storedStates[serverFrame] = DeltaTable:DeepCopy(currentState)
-	return stateDelta, self.lastConfirmedPlayerStateFrame
+	return stateDelta, self.lastConfirmedPlayerStateFrame, false
 end
 
 

--- a/src/ServerScriptService/Packages/Chickynoid/Server/ServerModule.lua
+++ b/src/ServerScriptService/Packages/Chickynoid/Server/ServerModule.lua
@@ -664,9 +664,19 @@ function ServerModule:UpdatePlayerStatesToPlayers()
 			event.lastConfirmedCommand = playerRecord.chickynoid.lastConfirmedCommand
 			event.serverTime = self.serverSimulationTime
 			event.serverFrame = self.serverTotalFrames
-			event.playerStateDelta, event.playerStateDeltaFrame = playerRecord.chickynoid:ConstructPlayerStateDelta(self.serverTotalFrames)
 
-			playerRecord:SendUnreliableEventToClient(event)
+			local playerStateDelta, playerStateDeltaFrame, isFirstState = playerRecord.chickynoid:ConstructPlayerStateDelta(self.serverTotalFrames)
+
+			event.playerStateDelta = playerStateDelta
+			event.playerStateDeltaFrame = playerStateDeltaFrame
+
+			if (isFirstState == true) then
+				--since we're sending the full simulation, use a reliable remote
+				playerRecord:SendEventToClient(event)
+			else
+				playerRecord:SendUnreliableEventToClient(event)	
+			end
+			
 			
 			--Clear the error state flag 
 			playerRecord.chickynoid.errorState = Enums.NetworkProblemState.None


### PR DESCRIPTION
When too much data are added to simulation by new move types, it can reach a point where chickynoid starts spamming 'Unreliable Event dropped as its payload is too large. Consider reducing the total size of the arguments. Payload went over by: X bytes'

### Explanation: 
After a chickynoid is spawned in, that chickynoid's ``lastSeenState`` property will be nil until it receives a command with a valid ``playerStateFrame`` which will then allow the ``lastSeenState`` to be stored.
``ServerModule.UpdatePlayerStatesToPlayers`` calls ``playerRecord.chickynoid:ConstructPlayerStateDelta(self.serverTotalFrames)`` which is meant to return a state delta dictionary of only the simulation values that were changed between the last frame and the current frame, using ``lastSeenState`` for comparison - however, as during the first few frames of a chickynoid spawning in there is no ``lastSeenState`` for it to compare to, the player state delta returned will be the ENTIRE simulation instead. With stock chickynoid, this is not a problem, as the entire simulation can fit within the data limit of an unreliable remote event, but when the simulation is modified by adding new move states which each modify the simulation to include new data - there will be a point where the simulation gets big enough to surpass the limit which will cause the proceeding unreliable events to drop. And when the events start to be dropped, the client will never receive their ``EventType.State`` event and will never have a ``playerStateFrame`` to send with their commands, causing all unreliable events coming from EventType.State to drop 

I've fixed this by making it so when ``playerRecord.chickynoid.ConstructPlayerStateDelta`` returns the full simulation due to an uninitiated ``lastSeenState``, that event will use a reliable remote so that it can 100% go through. Events of this type would still use the unreliable remote so long as the player state delta is not the full simulation