### PR TITLE
bot optimizations

### DIFF
--- a/src/ServerScriptService/Packages/Chickynoid/Server/Bots.lua
+++ b/src/ServerScriptService/Packages/Chickynoid/Server/Bots.lua
@@ -117,10 +117,10 @@ function module:MakeBots(Server, numBots)
 			if (math.random() < 0.01) then
 				playerRecord.waitTime = math.random() * 5                
 			end 
-			event[1] = CommandLayout:EncodeCommand(command)
+			event[1] = command
 			playerRecord.frame += 1
 			if (playerRecord.chickynoid) then
-				playerRecord.chickynoid:HandleEvent(Server, event)
+				playerRecord.chickynoid:HandleEvent(Server, event, true)
 			end
 		end
 	end

--- a/src/ServerScriptService/Packages/Chickynoid/Server/ServerChickynoid.lua
+++ b/src/ServerScriptService/Packages/Chickynoid/Server/ServerChickynoid.lua
@@ -105,8 +105,8 @@ function ServerChickynoid:Destroy()
     end
 end
 
-function ServerChickynoid:HandleEvent(server, event)
-    self:HandleClientUnreliableEvent(server, event, false)
+function ServerChickynoid:HandleEvent(server, event, isBotEvent)
+    self:HandleClientUnreliableEvent(server, event, false, isBotEvent)
 end
 
 --[=[
@@ -228,15 +228,29 @@ end
 	@param event table -- The event sent by the client.
 	@private
 ]=]
-function ServerChickynoid:HandleClientUnreliableEvent(server, event, fakeCommand)
+function ServerChickynoid:HandleClientUnreliableEvent(server, event, fakeCommand, isBotEvent)
 
 	if (event[2] ~= nil) then
-		local prevCommand = CommandLayout:DecodeCommand(event[2])
+		local prevCommand
+
+		if (isBotEvent == true) then
+			prevCommand = event[2]
+		else
+			prevCommand = CommandLayout:DecodeCommand(event[2])
+		end
+		
 		self:ProcessCommand(server, prevCommand, fakeCommand, true)
 	end
 	
 	if (event[1] ~= nil) then
-		local command = CommandLayout:DecodeCommand(event[1])		
+		local command
+
+		if (isBotEvent == true) then
+			command = event[1]
+		else
+			command = CommandLayout:DecodeCommand(event[1])
+		end
+
 		self:ProcessCommand(server, command, fakeCommand, false)
 	end
 end

--- a/src/ServerScriptService/Packages/Chickynoid/Server/ServerModule.lua
+++ b/src/ServerScriptService/Packages/Chickynoid/Server/ServerModule.lua
@@ -383,6 +383,12 @@ function ServerModule:SendWorldState(playerRecord)
 	if (playerRecord.loaded == false) then
 		return
 	end
+
+	if (playerRecord.dummy == true) then
+		--Don't compile world state for bots
+		playerRecord.pendingWorldState = false
+		return
+	end
 	
     local event = {}
     event.t = Enums.EventType.WorldState


### PR DESCRIPTION
1. When a client sends a command to the server, that command is encoded on the client then decoded on the server. This is also done by bots whenever they generate a command, however, there's no need for this encoding/decoding process for bots because they pass on their command directly to the server which immediately decodes it. I changed it so that bots pass on their raw command and bypass the decoding which greatly improves performance for each bot 

2. Whenever a player joins or leaves the game, ``ServerModule.SendWorldState`` will be ran on every chickynoid character, which goes through every chickynoid character to compile the world data to be sent to each player. However, even for bots which don't have a client, ``ServerModule.SendWorldState`` will still go through its entire process including iterating through every chickynoid character. This makes it so when the server has a big number of bots, every time a player joins / rejoins there will be a brief drop in server performance due to all the world state data compiling going on for every bot. I've made it so this function doesn't try to compile world state data for bots 